### PR TITLE
cas du "0" (ou "|"?) au début d'une ligne "s"

### DIFF
--- a/tabvar.typ
+++ b/tabvar.typ
@@ -844,7 +844,24 @@
                 name: "sign" + str(i) + str(j),
               )
 
-              if j != 0 {
+              if contents.at(i).at(j).at(0) == "0" {
+                set-style(..line-style)
+                line(
+                  (coordX.at(j).at(0), coordY.at(i).at(0) - coordY.at(i).at(1) / 2),
+                  (coordX.at(j).at(0), coordY.at(i).at(0) + coordY.at(i).at(1) / 2),
+                  name: "zero",
+                )
+                content(
+                  "zero.mid",
+                  $ 0 $,
+                )
+              } else if contents.at(i).at(j).first() == "|" {
+                set-style(..line-style)
+                line(
+                  (coordX.at(j).at(0), coordY.at(i).at(0) - coordY.at(i).at(1) / 2),
+                  (coordX.at(j).at(0), coordY.at(i).at(0) + coordY.at(i).at(1) / 2),
+                )
+              } else if j != 0 {
                 set-style(..line-style)
                 if contents.at(i).at(j).at(0) == "||" {
                   set-style(..table-style)
@@ -855,21 +872,6 @@
                   line(
                     (coordX.at(j).at(0) + 0.07, coordY.at(i).at(0) - coordY.at(i).at(1) / 2),
                     (coordX.at(j).at(0) + 0.07, coordY.at(i).at(0) + coordY.at(i).at(1) / 2),
-                  )
-                } else if contents.at(i).at(j).at(0) == "0" {
-                  line(
-                    (coordX.at(j).at(0), coordY.at(i).at(0) - coordY.at(i).at(1) / 2),
-                    (coordX.at(j).at(0), coordY.at(i).at(0) + coordY.at(i).at(1) / 2),
-                    name: "zero",
-                  )
-                  content(
-                    "zero.mid",
-                    $ 0 $,
-                  )
-                } else if contents.at(i).at(j).first() == "|" {
-                  line(
-                    (coordX.at(j).at(0), coordY.at(i).at(0) - coordY.at(i).at(1) / 2),
-                    (coordX.at(j).at(0), coordY.at(i).at(0) + coordY.at(i).at(1) / 2),
                   )
                 } else {
                   line(

--- a/tabvar.typ
+++ b/tabvar.typ
@@ -817,7 +817,7 @@
 
         if label.at(i).last() == "s" {
           // panic si il y a plus ou moins d’éléments qu’il faudrais
-          if contents.at(i).at(-1) == "||" {
+          if ("0", "|", "||").contains(contents.at(i).at(-1)) {
             if contents.at(i).len() != domain.len() {
               panic("TabVar: Wrong number of elements in the table number " + str(i + 1))
             }
@@ -1110,6 +1110,25 @@
             line(
               (decalage_domaine - 0.15, coordY.at(i).at(0) - coordY.at(i).at(1) / 2),
               (decalage_domaine - 0.15, coordY.at(i).at(0) + coordY.at(i).at(1) / 2),
+            )
+          } else if contents.at(i).at(-1) == "0" {
+            // Si zéro à la fin
+            set-style(..line-style)
+            line(
+              (coordX.at(-1).at(0), coordY.at(i).at(0) - coordY.at(i).at(1) / 2),
+              (coordX.at(-1).at(0), coordY.at(i).at(0) + coordY.at(i).at(1) / 2),
+              name: "zero",
+            )
+            content(
+              "zero.mid",
+              $ 0 $,
+            )
+          } else if contents.at(i).at(-1) == "|" {
+            // Si barre à la fin
+            set-style(..line-style)
+            line(
+              (coordX.at(-1).at(0), coordY.at(i).at(0) - coordY.at(i).at(1) / 2),
+              (coordX.at(-1).at(0), coordY.at(i).at(0) + coordY.at(i).at(1) / 2),
             )
           } else {
             if type(contents.at(i).at(-1)) == array and contents.at(i).at(-1).len() == 0 {


### PR DESCRIPTION
Bonjour,

J'ai parfois besoin d'un zéro au début d'une ligne de signe (par exemple dans ma correction du sujet de Bac Asie Pacifique du 9 juin 2026), j'ai donc légèrement réordonné les conditions pour permettre ce cas (le code en lui-même ne change pas, j'ai juste retiré le cas `contents.at(i).at(j).at(0) == "0"` de la condition `if j != 0`).

J'ai également permis "|" en première position mais là j'ai un peu plus un doute, ça ressemble beaucoup au "||" en première colonne (même si l'espacement est légèrement différent).

De mon côté, ce léger changement marche parfaitement sur mon fichier (qui compilait d'ailleurs avec la version 0.2.4 de Universe, il ne montrait juste pas le 0 en début de ligne) et ne semble pas géner sur d'autres tableaux.

Merci encore pour le paquet, il me sert tout le temps ! 

**EDIT** : Je me suis aperçu que j'avais le même problème en fin de ligne (sin(x) vaut 0 en 0 et en 2pi, les deux extrémités de l'intervalle d'étude) et pour le coup, ça me donne une bonne justification pour traiter "|" également car on peut avoir d'autres lignes ou ces extrémités ne s'annulent pas… On peut ne rien y mettre mais esthétiquement avoir un seul trait sur toute la hauteur du tableau avec des zéros sur certaines lignes est plus plaisant. Je te joins un exemple d'utilisation :
<img width="564" height="298" alt="tabvar-zeros" src="https://github.com/user-attachments/assets/d178ddb8-a513-4dbb-b5ff-689529a307b8" />
